### PR TITLE
CI: install packages via built-in system Python (not conda)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,19 +57,29 @@ jobs:
           mamba-version: "*"
           channels: conda-forge
 
-      - name: Install documentation-building requirements
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install documentation-building requirements with apt/dpkg
+        run: |
+          set -vxeuo pipefail
+          wget --progress=dot:giga "https://github.com/jgm/pandoc/releases/download/3.1.6.1/pandoc-3.1.6.1-1-amd64.deb" -O /tmp/pandoc.deb
+          sudo dpkg -i /tmp/pandoc.deb
+          # conda install -c conda-forge -y pandoc
+          which pandoc
+          pandoc --version
+
+      - name: Install documentation-building requirements with pip
         run: |
           # For reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
           set -vxeo pipefail
 
-          conda env list
-          # mamba install -c conda-forge shadow3 srwpy
-          mamba install -c conda-forge pandoc
           pip install --upgrade pip wheel
           pip install -v .
           pip install -r requirements-dev.txt
           pip list
-          conda list
 
       - name: Build Docs
         run: make -C docs/ html

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,28 +46,30 @@ jobs:
       #     mkdir -v -p ~/.config/databroker/
       #     wget https://raw.githubusercontent.com/NSLS-II/sirepo-bluesky/main/examples/local.yml -O ~/.config/databroker/local.yml
 
-      - name: Set up Python ${{ matrix.python-version }} with conda
-        uses: conda-incubator/setup-miniconda@v2
+      # - name: Set up Python ${{ matrix.python-version }} with conda
+      #   uses: conda-incubator/setup-miniconda@v2
+      #   with:
+      #     activate-environment: ${{ env.REPOSITORY_NAME }}-py${{ matrix.python-version }}
+      #     auto-update-conda: true
+      #     miniconda-version: "latest"
+      #     python-version: ${{ matrix.python-version }}
+      #     mamba-version: "*"
+      #     channels: conda-forge
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          activate-environment: ${{ env.REPOSITORY_NAME }}-py${{ matrix.python-version }}
-          auto-update-conda: true
-          miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge
 
       - name: Install the package and its dependencies
         run: |
           # For reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
           set -vxeo pipefail
 
-          conda env list
-
           pip install --upgrade pip wheel
           pip install -v .
           pip install -r requirements-dev.txt
           pip list
-          conda list
 
       - name: Test with pytest
         run: |


### PR DESCRIPTION
This is to speed up the CI runs (done the same way as in https://github.com/NSLS-II/sirepo-bluesky).